### PR TITLE
Change the readme to mark the repo as unused.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,11 @@
-# Elm Plans
+# DEPRECATED
 
-A central home for future plans for [Elm](http://elm-lang.org).
+This repository was made as a central home for plans for the Elm language,
+but is no longer in use.
 
-
-## Feature Requests
-
-When you want a new feature to the language or core tools, open an issue here
-proposing the idea.
-
+The repository is maintained to store the history of discussions.
 
 ## Collaborate
 
-We have a nice list of [projects](https://github.com/elm-lang/projects) that
-would work great as community projects!
-
-
-## Roadmap
-
-A rough prioritization of features that are planned and discussed.
+Look at the list of [projects](https://github.com/elm-lang/projects) instead if
+you're interested in contributing to the future of Elm!


### PR DESCRIPTION
But leave a link to the elm-projects repository, since there are
some "help wanted" projects listed there still.

@evancz - Per discussion on the mailing list.

The simplest way to hang on to discussions in the history of issues is to just not delete the repository; nobody's been attempting to open issues or PRs here, and they probably won't start after the change to the README, so it doesn't hurt anything.  Otherwise, issues can be exported from Github's API.
